### PR TITLE
Update dependency to webkit2gtk-4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set (DEPS_PACKAGES
 )
 
 find_package(PkgConfig)
-pkg_check_modules(DEPS REQUIRED libxml-2.0 granite gtk+-3.0 gstreamer-1.0 gstreamer-pbutils-1.0 gthread-2.0 sqlite3 clutter-gtk-1.0 gdk-x11-3.0 libsoup-2.4 json-glib-1.0 webkit2gtk-3.0 gee-0.8)
+pkg_check_modules(DEPS REQUIRED libxml-2.0 granite gtk+-3.0 gstreamer-1.0 gstreamer-pbutils-1.0 gthread-2.0 sqlite3 clutter-gtk-1.0 gdk-x11-3.0 libsoup-2.4 json-glib-1.0 webkit2gtk-4.0 gee-0.8)
 
 #
 # Libunity


### PR DESCRIPTION
Updated in pkg_check_modules as webkit2gtk-4.0 is used in DEPS_PACKAGES.

Otherwise the build fails on Arch Linux.