### PR TITLE
missing colon in the "preferences" dialog box

### DIFF
--- a/po/vocal.pot
+++ b/po/vocal.pot
@@ -462,7 +462,7 @@ msgid "Keep my library clean:"
 msgstr ""
 
 #: ../src/Widgets/SettingsDialog.vala:110
-msgid "Show podcast names below cover art"
+msgid "Show podcast names below cover art:"
 msgstr ""
 
 #: ../src/Widgets/SettingsDialog.vala:140

--- a/src/Widgets/SettingsDialog.vala
+++ b/src/Widgets/SettingsDialog.vala
@@ -107,7 +107,7 @@ namespace Vocal {
             content_box.add(autoclean_box);
 
             // Show name label option
-            show_name_label_label = new Gtk.Label(_("Show podcast names below cover art"));
+            show_name_label_label = new Gtk.Label(_("Show podcast names below cover art:"));
             show_name_label_label.justify = Gtk.Justification.LEFT;
             show_name_label_label.set_property("xalign", 0);
             show_name_label_label.margin_left = 5;


### PR DESCRIPTION
Just a random fix: all the labels in the "preferences" dialog box had a colon at the end except this one.