### PR TITLE
Don't hardcode images path, and respect standard of installation directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project (vocal)
 cmake_minimum_required (VERSION 2.8)
 cmake_policy (VERSION 2.6)
 
-set (DATADIR "${CMAKE_INSTALL_PREFIX}/share/vocal")
+set (DATADIR "${CMAKE_INSTALL_PREFIX}/share")
 set (PKGDATADIR "${DATADIR}/vocal")
 set (GETTEXT_PACKAGE "vocal")
 set (RELEASE_NAME "Voyager")

--- a/cmake/Translations.cmake
+++ b/cmake/Translations.cmake
@@ -18,7 +18,7 @@ macro (add_translations_directory NLS_PACKAGE)
         add_custom_command (TARGET i18n COMMAND ${MSGFMT_EXECUTABLE} -o ${MO_OUTPUT} ${PO_INPUT})
 
         install (FILES ${MO_OUTPUT} DESTINATION
-            share/locale-langpack/${PO_INPUT_BASE}/LC_MESSAGES
+            share/locale/${PO_INPUT_BASE}/LC_MESSAGES
             RENAME ${NLS_PACKAGE}.mo)
     endforeach (PO_INPUT ${PO_FILES})
 endmacro (add_translations_directory)

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -632,7 +632,7 @@ namespace Vocal {
 
             // Create a welcome screen and add it to the notebook (no matter if first run or not)
             welcome = new Granite.Widgets.Welcome (_("Welcome to Vocal"), _("Build Your Library By Adding Podcasts"));
-            welcome.append("preferences-desktop-online-accounts", _("Browse Podcasts"),
+            welcome.append(on_elementary ? "preferences-desktop-online-accounts" : "applications-internet", _("Browse Podcasts"),
                  _("Browse through podcasts and choose some to add to your library."));
             welcome.append("list-add", _("Add a New Feed"), _("Provide the web address of a podcast feed."));
             welcome.append("document-open", _("Import Subscriptions"),

--- a/src/Objects/Podcast.vala
+++ b/src/Objects/Podcast.vala
@@ -53,7 +53,7 @@ namespace Vocal {
                 }
                 // In rare instances where album art is not available at all, provide a "missing art" image to use
                 // in library view
-                return """file:///usr/share/vocal/vocal-missing.png""";
+                return "file://" + Constants.PKGDATADIR + "/vocal-missing.png";
             }
 
 		    // If the URI begins with "file://" set local uri, otherwise set the remote uri

--- a/src/Vocal.vala
+++ b/src/Vocal.vala
@@ -42,7 +42,7 @@ namespace Vocal {
             build_version = Constants.VERSION;
             build_version_info = Constants.VERSION_INFO;
 
-            app_years = "2015";
+            app_years = "2015-2016";
             app_icon = "vocal";
             app_launcher = "vocal.desktop";
             application_id = "net.launchpad.vocal";
@@ -105,9 +105,8 @@ namespace Vocal {
 
             // Init internationalization support
             string package_name = Constants.GETTEXT_PACKAGE;
-            string langpack_dir = Constants.DATADIR.replace("/vocal", "/locale-langpack");
             Intl.setlocale (LocaleCategory.ALL, "");
-            Intl.bindtextdomain (package_name, langpack_dir);
+            Intl.bindtextdomain (package_name, Constants.DATADIR + "/locale");
             Intl.bind_textdomain_codeset (package_name, "UTF-8");
             Intl.textdomain (package_name);
 

--- a/src/Widgets/CoverArt.vala
+++ b/src/Widgets/CoverArt.vala
@@ -69,7 +69,7 @@ namespace Vocal {
 	            image = new Gtk.Image.from_pixbuf(coverart_pixbuf);
 
 	            // Load the banner to be drawn on top of the cover art
-				File triangle_file = GLib.File.new_for_uri("""file:///usr/share/vocal/banner.png""");
+                    File triangle_file = GLib.File.new_for_path(GLib.Path.build_filename (Constants.PKGDATADIR, "banner.png"));
 	            InputStream triangle_input_stream = triangle_file.read();
 	            var triangle_pixbuf = new Gdk.Pixbuf.from_stream_at_scale(triangle_input_stream, 75, 75, true);
 	            triangle = new Gtk.Image.from_pixbuf(triangle_pixbuf);

--- a/src/Widgets/DirectoryArt.vala
+++ b/src/Widgets/DirectoryArt.vala
@@ -113,7 +113,7 @@ namespace Vocal {
 			hor_box.margin_right = 10;
 
             // Load the album artwork
-            var missing_pixbuf = new Gdk.Pixbuf.from_file_at_scale("""//usr/share/vocal/vocal-missing.png""",
+            var missing_pixbuf = new Gdk.Pixbuf.from_file_at_scale(GLib.Path.build_filename (Constants.PKGDATADIR, "vocal-missing.png"),
                                                                    170, 170, true);
             var image = new Gtk.Image.from_pixbuf(missing_pixbuf);
             image.margin = 2;


### PR DESCRIPTION
Avoid to hardcode images path, in order to install Vocal on BSD systems. Second changes respect "standard" location of traduction files (usually ${PREFIX}/share/locale).